### PR TITLE
Upgrade to MariaDB 10.3 and Centos 7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mariadb-vagrant
-A simple vagrant box with MariaDB 10.1 and CentOS 7.2.
+A simple vagrant box with MariaDB 10.3 and CentOS 7.5.
 
 ## Getting started
 1. Clone this repository
@@ -13,9 +13,9 @@ After the initial install, you may need to run `vagrant reload` to restart the V
 ## Connecting to MariaDB
 Using any client that connects to MySQL, use the following settings:
 
-Host: `127.0.0.1`  
-User: `root`  
-Password: `password`  
+Host: `127.0.0.1`
+User: `root`
+Password: `password`
 Port: `3306`
 
 Ensure that MySQL is not running on your machine before starting up, as there will be a port conflict. Vagrant will soon tell you :)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,14 +5,12 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "bento/centos-7.2"
+  config.vm.box = "bento/centos-7"
+  config.vm.box_version = "201808.24.0"
   config.vm.box_check_update = false
   config.vbguest.auto_update = true
-  
-  # workaround the vagrant 1.8.5 bug
-  config.ssh.insert_key = false
-  
+
   config.vm.network :forwarded_port, guest: 3306, host: 3306
   config.vm.provision :shell, :path => "install.sh"
-  config.vm.synced_folder ".", "/vagrant", :mount_options => ["dmode=777", "fmode=666"]
+
 end

--- a/mariadb.repo
+++ b/mariadb.repo
@@ -1,5 +1,7 @@
-[mariadb] 
-name = MariaDB 
-baseurl = http://yum.mariadb.org/10.1/centos7-amd64 
-gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB 
+# MariaDB 10.3 CentOS repository list - created 2018-09-22 07:23 UTC
+# http://downloads.mariadb.org/mariadb/repositories/
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/10.3/centos7-amd64
+gpgkey=https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
 gpgcheck=1


### PR DESCRIPTION
- upgrade to MariaDb 10.3, Centos 7.5
- remove workaround for Vagrant 1.8.5 (tested with Vagrant 2.0.1)
- remove synced folder setting